### PR TITLE
Bump msrv to 1.65

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,11 @@ on:
   push:
     branches: [master]
   pull_request:
-  schedule:
-    - cron: '0 0 * * 3' # At 12:00 AM, only on Wednesday
   label:
     types: [created, edited]
+  schedule:
+    - cron: '0 0 * * 3' # At 12:00 AM, only on Wednesday
+  workflow_dispatch:
 
 jobs:
   build-test:
@@ -17,7 +18,7 @@ jobs:
           - { os: windows-latest, rust-version: stable,  shell: 'msys2 {0}' }
           - { os: macos-11,       rust-version: stable,  shell: bash }
           - { os: ubuntu-20.04,   rust-version: stable,  shell: bash, extra: true }
-          - { os: ubuntu-20.04,   rust-version: 1.63,    shell: bash }
+          - { os: ubuntu-20.04,   rust-version: 1.65,    shell: bash }
           - { os: ubuntu-20.04,   rust-version: beta,    shell: bash }
           - { os: ubuntu-20.04,   rust-version: nightly, shell: bash }
     defaults:


### PR DESCRIPTION
[Recent commits](https://github.com/mthom/scryer-prolog/commit/7f45ac3f7a947e3d7b6556cddea9110622b675fd#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87eL1611-R1577) have updated rug to 1.19, which [only supports rust 1.65 and later](https://gitlab.com/tspiteri/rug#version-1190-news-2023-01-06).

This bumps the effective msrv for scryer-prolog to rust 1.65. This pr updates that in the ci script.

